### PR TITLE
Fix Barchart Hover Text

### DIFF
--- a/config/larapex-charts.php
+++ b/config/larapex-charts.php
@@ -13,7 +13,7 @@ return [
 
     'font_family' => 'Helvetica, Arial, sans-serif',
 
-    'font_color' => '#373d3f',
+    'font_color' => '#000000',
 
     /*
     |--------------------------------------------------------------------------

--- a/resources/views/graphs/index.blade.php
+++ b/resources/views/graphs/index.blade.php
@@ -9,22 +9,20 @@
     <div class="py-12">
         <div class="max-w-7xl mx-auto sm:px-6 lg:px-8">
             <div class="bg-white dark:bg-gray-800 overflow-hidden shadow-sm sm:rounded-lg">
-                <div class="text-gray-900 dark:text-gray-100">
 
-                    <div class="p-4 m-4 dark:bg-gray-200 sm:rounded-lg shadow">
-                        {!! $chartWeek->container() !!}
-                    </div>
-                    <div class="p-4 m-4 dark:bg-gray-200 sm:rounded-lg shadow">
-                        {!! $chartWeekWeighted->container() !!}
-                    </div>
-                    <div class="p-4 m-4 dark:bg-gray-200 sm:rounded-lg shadow">
-                        {!! $chartMonth->container() !!}
-                    </div>
-                    <div class="p-4 m-4 dark:bg-gray-200 sm:rounded-lg shadow">
-                        {!! $chartYear->container() !!}
-                    </div>
-
+                <div class="p-4 m-4 dark:bg-gray-200 sm:rounded-lg shadow">
+                    {!! $chartWeek->container() !!}
                 </div>
+                <div class="p-4 m-4 dark:bg-gray-200 sm:rounded-lg shadow">
+                    {!! $chartWeekWeighted->container() !!}
+                </div>
+                <div class="p-4 m-4 dark:bg-gray-200 sm:rounded-lg shadow">
+                    {!! $chartMonth->container() !!}
+                </div>
+                <div class="p-4 m-4 dark:bg-gray-200 sm:rounded-lg shadow">
+                    {!! $chartYear->container() !!}
+                </div>
+
             </div>
         </div>
     </div>


### PR DESCRIPTION
The hover text was too light to read. Updated to a darker color (default).